### PR TITLE
add new 'check_for_pending_change' test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -198,7 +198,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "cfg-if"
@@ -520,18 +520,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "clipboard-win"
@@ -661,7 +661,7 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "json",
  "orchard",
  "portpicker",
@@ -768,6 +768,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1257,12 +1268,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes 1.6.0",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -1270,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
 
 [[package]]
 name = "httpdate"
@@ -1288,9 +1299,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes 1.6.0",
  "futures-channel",
@@ -1337,7 +1348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "rustls 0.20.9",
  "rustls-native-certs",
@@ -1351,7 +1362,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1417,13 +1428,133 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -1615,6 +1746,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "litrs"
@@ -2158,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2418,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2430,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2441,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "remove_dir_all"
@@ -3001,6 +3138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3194,17 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "system-configuration"
@@ -3194,6 +3348,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,7 +3481,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -3478,12 +3642,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,9 +3664,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "universal-hash"
@@ -3549,9 +3707,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3559,10 +3717,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "utf16_iter"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -3929,6 +4099,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,6 +4124,30 @@ name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "synstructure",
+]
 
 [[package]]
 name = "zcash_address"
@@ -4126,6 +4332,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,6 +4366,28 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4177,7 +4426,7 @@ version = "0.1.0"
 dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls",
  "prost",
  "rustls-pemfile 1.0.4",

--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -679,7 +679,7 @@ pub mod scenarios {
                 DarksideSender::IndexedClient(n) => self.get_lightclient(n),
                 DarksideSender::ExternalClient(lc) => lc,
             };
-            zingo_testutils::lightclient::from_inputs::send(
+            zingo_testutils::lightclient::from_inputs::quick_send(
                 lightclient,
                 vec![(receiver_address, value, None)],
             )
@@ -718,7 +718,6 @@ pub mod scenarios {
             // We can't just take a reference to a LightClient, as that might be a reference to
             // a field of the DarksideScenario which we're taking by exclusive (i.e. mut) reference
             sender: DarksideSender<'_>,
-            pool_to_shield: PoolType,
         ) -> (&mut DarksideEnvironment, RawTransaction) {
             self.staged_blockheight = self.staged_blockheight.add(1);
             self.darkside_connector
@@ -731,9 +730,7 @@ pub mod scenarios {
                 DarksideSender::ExternalClient(lc) => lc,
             };
             // upgrade sapling
-            zingo_testutils::lightclient::from_inputs::shield(lightclient, &[pool_to_shield], None)
-                .await
-                .unwrap();
+            lightclient.quick_shield().await.unwrap();
             let mut streamed_raw_txns = self
                 .darkside_connector
                 .get_incoming_transactions()
@@ -772,10 +769,9 @@ pub mod scenarios {
             // We can't just take a reference to a LightClient, as that might be a reference to
             // a field of the DarksideScenario which we're taking by exclusive (i.e. mut) reference
             sender: DarksideSender<'_>,
-            pool_to_shield: PoolType,
             chainbuild_file: &File,
         ) -> &mut DarksideEnvironment {
-            let (_, raw_tx) = self.shield_transaction(sender, pool_to_shield).await;
+            let (_, raw_tx) = self.shield_transaction(sender).await;
             write_raw_transaction(&raw_tx, BranchId::Nu5, chainbuild_file);
             self
         }

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -544,6 +544,7 @@ async fn reorg_changes_outgoing_tx_height() {
     );
 
     let before_reorg_transactions = light_client.list_txsummaries().await;
+    dbg!(&before_reorg_transactions);
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -557,10 +558,14 @@ async fn reorg_changes_outgoing_tx_height() {
 
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
+    // FIXME: fails to create a sent valuetransfer with quick_send
     let sent_tx_id =
         from_inputs::quick_send(&light_client, [(recipient_string, amount, None)].to_vec())
             .await
             .unwrap();
+    // let sent_tx_id = from_inputs::send(&light_client, [(recipient_string, amount, None)].to_vec())
+    //     .await
+    //     .unwrap();
 
     println!("SENT TX ID: {:?}", sent_tx_id);
 
@@ -593,7 +598,7 @@ async fn reorg_changes_outgoing_tx_height() {
     // check that the outgoing transaction has the correct height before
     // the reorg is triggered
 
-    println!("{:?}", light_client.list_txsummaries().await);
+    dbg!(light_client.list_txsummaries().await);
 
     assert_eq!(
         light_client
@@ -687,7 +692,6 @@ async fn reorg_changes_outgoing_tx_height() {
 }
 
 async fn prepare_changes_outgoing_tx_height_before_reorg(uri: http::Uri) -> Result<(), String> {
-    dbg!(&uri);
     let connector = DarksideConnector(uri.clone());
 
     let mut client = connector.get_client().await.unwrap();

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -557,9 +557,10 @@ async fn reorg_changes_outgoing_tx_height() {
 
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
-    let sent_tx_id = from_inputs::send(&light_client, [(recipient_string, amount, None)].to_vec())
-        .await
-        .unwrap();
+    let sent_tx_id =
+        from_inputs::quick_send(&light_client, [(recipient_string, amount, None)].to_vec())
+            .await
+            .unwrap();
 
     println!("SENT TX ID: {:?}", sent_tx_id);
 
@@ -795,9 +796,10 @@ async fn reorg_expires_outgoing_tx_height() {
 
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
-    let sent_tx_id = from_inputs::send(&light_client, [(recipient_string, amount, None)].to_vec())
-        .await
-        .unwrap();
+    let sent_tx_id =
+        from_inputs::quick_send(&light_client, [(recipient_string, amount, None)].to_vec())
+            .await
+            .unwrap();
 
     println!("SENT TX ID: {:?}", sent_tx_id);
 
@@ -975,9 +977,10 @@ async fn reorg_changes_outgoing_tx_index() {
 
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
-    let sent_tx_id = from_inputs::send(&light_client, [(recipient_string, amount, None)].to_vec())
-        .await
-        .unwrap();
+    let sent_tx_id =
+        from_inputs::quick_send(&light_client, [(recipient_string, amount, None)].to_vec())
+            .await
+            .unwrap();
 
     println!("SENT TX ID: {:?}", sent_tx_id);
 

--- a/darkside-tests/tests/network_interruption_tests.rs
+++ b/darkside-tests/tests/network_interruption_tests.rs
@@ -107,11 +107,7 @@ async fn shielded_note_marked_as_change_chainbuild() {
             .await;
         scenario.get_lightclient(0).do_sync(false).await.unwrap();
         scenario
-            .shield_and_write_transaction(
-                DarksideSender::IndexedClient(0),
-                PoolType::Shielded(ShieldedProtocol::Sapling),
-                &chainbuild_file,
-            )
+            .shield_and_write_transaction(DarksideSender::IndexedClient(0), &chainbuild_file)
             .await;
     }
 

--- a/libtonode-tests/tests/chain_generics.rs
+++ b/libtonode-tests/tests/chain_generics.rs
@@ -63,6 +63,10 @@ mod chain_generics {
     async fn send_required_dust() {
         fixtures::send_required_dust::<LibtonodeEnvironment>().await;
     }
+    #[tokio::test]
+    async fn note_selection_order() {
+        fixtures::note_selection_order::<LibtonodeEnvironment>().await;
+    }
     mod environment {
         use zcash_client_backend::PoolType;
 

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3309,6 +3309,8 @@ mod slow {
         assert_eq!(loaded_balance.unverified_orchard_balance, Some(0),);
         check_client_balances!(loaded_client, o: 100_000 s: 0 t: 0 );
     }
+
+    // FIXME: same bug, sent value transfer not created by quick_send
     #[tokio::test]
     async fn by_address_finsight() {
         let (regtest_manager, _cph, faucet, recipient) =
@@ -3326,11 +3328,7 @@ mod slow {
             .unwrap();
         from_inputs::quick_send(&faucet, vec![(&base_uaddress, 1_000u64, Some("1"))])
             .await
-            .expect(
-                "We only have sapling notes, plus a pending orchard note from the \
-            previous send. If we're allowed to select pending notes, we'll attempt \
-            to select that one, and this will fail",
-            );
+            .unwrap();
         assert_eq!(
             JsonValue::from(faucet.do_total_memobytes_to_address().await)[&base_uaddress].pretty(4),
             "2".to_string()
@@ -3343,6 +3341,7 @@ mod slow {
             "6".to_string()
         );
     }
+
     #[tokio::test]
     async fn aborted_resync() {
         let (regtest_manager, _cph, faucet, recipient, _txid) =

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2252,7 +2252,7 @@ mod slow {
             .unwrap();
 
         let client_2_saplingaddress = get_base_address_macro!(recipient, "sapling");
-        // Send three transfers in increasing 1000 zat increments
+        // Send three transfers in increasing 10,000 zat increments
         // These are sent from the coinbase funded client which will
         // subsequently receive funding via it's orchard-packed UA.
         let memos = ["1", "2", "3"];
@@ -2262,7 +2262,7 @@ mod slow {
                 .map(|n| {
                     (
                         client_2_saplingaddress.as_str(),
-                        n * 10000,
+                        n * 10_000,
                         Some(memos[(n - 1) as usize]),
                     )
                 })
@@ -2274,14 +2274,14 @@ mod slow {
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &recipient, 5)
             .await
             .unwrap();
-        // We know that the largest single note that 2 received from 1 was 3000, for 2 to send
-        // 3000 back to 1 it will have to collect funds from two notes to pay the full 3000
+        // We know that the largest single note that 2 received from 1 was 30_000, for 2 to send
+        // 30_000 back to 1 it will have to collect funds from two notes to pay the full 30_000
         // plus the transaction fee.
         from_inputs::quick_send(
             &recipient,
             vec![(
                 &get_base_address_macro!(faucet, "unified"),
-                30000,
+                30_000,
                 Some("Sending back, should have 2 inputs"),
             )],
         )

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2241,7 +2241,7 @@ mod slow {
     #[tokio::test]
     async fn note_selection_order() {
         // In order to fund a transaction multiple notes may be selected and consumed.
-        // To minimize note selection operations notes are consumed from largest to smallest.
+        // The algorithm selects the smallest covering note(s).
         // In addition to testing the order in which notes are selected this test:
         //   * sends to a sapling address
         //   * sends back to the original sender's UA
@@ -2252,7 +2252,7 @@ mod slow {
             .unwrap();
 
         let client_2_saplingaddress = get_base_address_macro!(recipient, "sapling");
-        // Send three transfers in increasing 10,000 zat increments
+        // Send three transfers in increasing 10_000 zat increments
         // These are sent from the coinbase funded client which will
         // subsequently receive funding via it's orchard-packed UA.
         let memos = ["1", "2", "3"];
@@ -2288,7 +2288,7 @@ mod slow {
         .await
         .unwrap();
         let client_2_notes = recipient.do_list_notes(false).await;
-        // The 3000 zat note to cover the value, plus another for the tx-fee.
+        // The 30_000 zat note to cover the value, plus another for the tx-fee.
         let first_value = client_2_notes["pending_sapling_notes"][0]["value"]
             .as_fixed_point_u64(0)
             .unwrap();
@@ -2296,8 +2296,8 @@ mod slow {
             .as_fixed_point_u64(0)
             .unwrap();
         assert!(
-            first_value == 30000u64 && second_value == 20000u64
-                || first_value == 20000u64 && second_value == 30000u64
+            first_value == 30_000u64 && second_value == 20_000u64
+                || first_value == 20_000u64 && second_value == 30_000u64
         );
         //);
         // Because the above tx fee won't consume a full note, change will be sent back to 2.

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -691,8 +691,9 @@ mod slow {
     use zcash_client_backend::{PoolType, ShieldedProtocol};
     use zcash_primitives::consensus::NetworkConstants;
     use zingo_testutils::lightclient::from_inputs;
-    use zingolib::lightclient::{
-        propose::ProposeSendError, send::send_with_proposal::QuickSendError,
+    use zingolib::{
+        lightclient::{propose::ProposeSendError, send::send_with_proposal::QuickSendError},
+        wallet::tx_map_and_maybe_trees::TxMapAndMaybeTreesTraitError,
     };
 
     use super::*;
@@ -1104,7 +1105,9 @@ mod slow {
                 )
                 .await,
                 Err(QuickSendError::ProposeSend(ProposeSendError::Proposal(
-                    zcash_client_backend::data_api::error::Error::NoSpendingKey(_)
+                    zcash_client_backend::data_api::error::Error::DataSource(
+                        TxMapAndMaybeTreesTraitError::NoSpendCapability
+                    )
                 )))
             ));
         }

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2997,12 +2997,13 @@ mod slow {
         };
         assert_eq!(seed_of_recipient, seed_of_recipient_restored);
     }
+
     #[tokio::test]
-    async fn list_txsummaries_check_fees() {
+    async fn pool_migration_check_fees() {
         // Check that list_txsummaries behaves correctly given different fee scenarios
         let (regtest_manager, _cph, mut client_builder, regtest_network) =
             scenarios::custom_clients_default().await;
-        let sapling_faucet = client_builder.build_faucet(false, regtest_network).await;
+        let faucet = client_builder.build_faucet(false, regtest_network).await;
         let pool_migration_client = client_builder
             .build_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false, regtest_network)
             .await;
@@ -3010,7 +3011,7 @@ mod slow {
         let pmc_sapling = get_base_address_macro!(pool_migration_client, "sapling");
         let pmc_unified = get_base_address_macro!(pool_migration_client, "unified");
         // Ensure that the client has confirmed spendable funds
-        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &sapling_faucet, 3)
+        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 3)
             .await
             .unwrap();
         macro_rules! bump_and_check_pmc {
@@ -3020,27 +3021,25 @@ mod slow {
             };
         }
 
-        // 1 pmc receives 100_000 orchard
-        //  # Expected Fees:
-        //    - legacy: 0
-        //    - 317:    0
-        from_inputs::quick_send(&sapling_faucet, vec![(&pmc_unified, 100_000, None)])
+        // pmc receives 100_000 orchard
+        from_inputs::quick_send(&faucet, vec![(&pmc_unified, 100_000, None)])
             .await
             .unwrap();
         bump_and_check_pmc!(o: 100_000 s: 0 t: 0);
 
-        // 2 to transparent and sapling from orchard
-        //  # Expected Fees:
-        //    - legacy: 10_000
-        //    - 317:    5_000 for transparent + 10_000 for orchard + 10_000 for sapling == 25_000
+        // to transparent and sapling from orchard
+        //
+        // Expected Fees:
+        // 5_000 for transparent + 10_000 for orchard + 10_000 for sapling == 25_000
         from_inputs::quick_send(
             &pool_migration_client,
             vec![(&pmc_taddr, 30_000, None), (&pmc_sapling, 30_000, None)],
         )
         .await
         .unwrap();
-        bump_and_check_pmc!(o: 30_000 s: 30_000 t: 30_000);
+        bump_and_check_pmc!(o: 15_000 s: 30_000 t: 30_000);
     }
+
     #[tokio::test]
     async fn from_t_z_o_tz_to_zo_tzo_to_orchard() {
         // Test all possible promoting note source combinations

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -695,7 +695,7 @@ mod fast {
 mod slow {
     use orchard::note_encryption::OrchardDomain;
     use zcash_client_backend::{PoolType, ShieldedProtocol};
-    use zcash_primitives::consensus::NetworkConstants;
+    use zcash_primitives::{consensus::NetworkConstants, transaction::fees::zip317::MARGINAL_FEE};
     use zingo_testutils::lightclient::from_inputs;
     use zingolib::{
         lightclient::{propose::ProposeSendError, send::send_with_proposal::QuickSendError},
@@ -1673,7 +1673,7 @@ mod slow {
         assert_eq!(balance.unverified_orchard_balance, Some(0));
         assert_eq!(
             balance.verified_orchard_balance.unwrap(),
-            625_000_000 - u64::from(MINIMUM_FEE)
+            625_000_000 - 4 * u64::from(MARGINAL_FEE)
         );
     }
     #[tokio::test]

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -1295,10 +1295,10 @@ mod slow {
             {
                 "block_height": 6,
                 "pending": false,
-                "datetime": 1694825595,
-                "txid": "4ee5a583e6462eb4c39f9d8188e855bb1e37d989fcb8b417cff93c27b006e72d",
+                "datetime": 1718023286,
+                "txid": "392da4b0abfc2b3938741301fc109ad2de7641a8054f2cda8c6fa33804b6385a",
                 "zec_price": null,
-                "amount": -30000,
+                "amount": -40000,
                 "outgoing_metadata": [
                     {
                         "address": "zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p",
@@ -1351,8 +1351,9 @@ mod slow {
 
         let expected_funds = recipient_initial_funds
             - first_send_to_sapling
+            - (4 * u64::from(MARGINAL_FEE))
             - first_send_to_transparent
-            - (2 * u64::from(MINIMUM_FEE));
+            - (3 * u64::from(MARGINAL_FEE));
         assert_eq!(
             recipient
                 .wallet

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2238,6 +2238,7 @@ mod slow {
         let post_rescan_transactions = faucet.do_list_transactions().await;
         assert_eq!(transactions, post_rescan_transactions);
     }
+    #[ignore]
     #[tokio::test]
     async fn note_selection_order() {
         // In order to fund a transaction multiple notes may be selected and consumed.

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -1163,7 +1163,7 @@ mod slow {
         from_inputs::quick_send(
             &faucet,
             vec![(
-                &get_base_address_macro!(recipient, "sapling"),
+                &get_base_address_macro!(recipient, "transparent"),
                 transparent_funding,
                 None,
             )],
@@ -1212,6 +1212,7 @@ mod slow {
             )
             .pretty(2)
         );
+        // TODO: Add asserts!
     }
     #[tokio::test]
     async fn send_to_ua_saves_full_ua_in_wallet() {

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2779,7 +2779,7 @@ mod slow {
                 "created_in_block" =>  4,
                 "datetime" =>  0,
                 "created_in_txid" => "",
-                "value" =>  14_000,
+                "value" =>  24_000,
                 "pending" =>  false,
                 "is_change" =>  false,
                 "address" =>  "uregtest1m8un60udl5ac0928aghy4jx6wp59ty7ct4t8ks9udwn8y6fkdmhe6pq0x5huv8v0pprdlq07tclqgl5fzfvvzjf4fatk8cpyktaudmhvjcqufdsfmktgawvne3ksrhs97pf0u8s8f8h",
@@ -2802,7 +2802,7 @@ mod slow {
                 &faucet,
                 vec![(
                     recipient1_diversified_addr[0].as_str().unwrap(),
-                    14_000,
+                    24_000,
                     Some("foo"),
                 )],
             )

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3775,6 +3775,8 @@ mod slow {
 }
 
 mod basic_transactions {
+    use std::cmp;
+
     use zingo_testutils::{get_base_address_macro, lightclient::from_inputs, scenarios};
 
     #[tokio::test]
@@ -3889,15 +3891,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&faucet, txid1.as_str()).await - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);
@@ -3923,15 +3923,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&faucet, txid2.as_str()).await - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid2);
 
-        let expected_fee_txid2 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid2 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid2.transparent_tx_actions
-        //             + tx_actions_txid2.sapling_tx_actions
-        //             + tx_actions_txid2.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid2 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid2.transparent_tx_actions
+                    + tx_actions_txid2.sapling_tx_actions
+                    + tx_actions_txid2.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid2);
 
         assert_eq!(calculated_fee_txid2, expected_fee_txid2 as u64);
@@ -3957,15 +3955,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&faucet, txid3.as_str()).await - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid3);
 
-        let expected_fee_txid3 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid3 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid3.transparent_tx_actions
-        //             + tx_actions_txid3.sapling_tx_actions
-        //             + tx_actions_txid3.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid3 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid3.transparent_tx_actions
+                    + tx_actions_txid3.sapling_tx_actions
+                    + tx_actions_txid3.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid3);
 
         assert_eq!(calculated_fee_txid3, expected_fee_txid3 as u64);
@@ -3974,7 +3970,7 @@ mod basic_transactions {
             &recipient,
             vec![(
                 get_base_address_macro!(faucet, "transparent").as_str(),
-                60_000,
+                55_000,
                 None,
             )],
         )
@@ -4008,18 +4004,16 @@ mod basic_transactions {
         println!("Transaction Actions:\n{:?}", tx_actions_txid4);
 
         let calculated_fee_txid4 =
-            zingo_testutils::total_tx_value(&recipient, txid4.as_str()).await - 60_000;
+            zingo_testutils::total_tx_value(&recipient, txid4.as_str()).await - 55_000;
         println!("Fee Paid: {}", calculated_fee_txid4);
 
-        let expected_fee_txid4 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid4 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid4.transparent_tx_actions
-        //             + tx_actions_txid4.sapling_tx_actions
-        //             + tx_actions_txid4.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid4 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid4.transparent_tx_actions
+                    + tx_actions_txid4.sapling_tx_actions
+                    + tx_actions_txid4.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid4);
 
         assert_eq!(calculated_fee_txid4, expected_fee_txid4 as u64);
@@ -4070,15 +4064,13 @@ mod basic_transactions {
         let calculated_fee_txid1 = zingo_testutils::total_tx_value(&faucet, txid1.as_str()).await;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);
@@ -4132,15 +4124,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&recipient, txid1.as_str()).await;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3048,157 +3048,294 @@ mod slow {
         // app and are not recommended in production.
         // An example is a transaction that "shields" both transparent and
         // sapling value into the orchard value pool.
+        async fn fees(client: &LightClient) -> u64 {
+            client
+                .list_txsummaries()
+                .await
+                .into_iter()
+                .filter_map(|x| {
+                    if let zingolib::wallet::data::summaries::ValueTransferKind::Fee { amount } =
+                        x.kind
+                    {
+                        Some(amount)
+                    } else {
+                        None
+                    }
+                })
+                .sum::<u64>()
+        }
         let (regtest_manager, _cph, mut client_builder, regtest_network) =
             scenarios::custom_clients_default().await;
         let sapling_faucet = client_builder.build_faucet(false, regtest_network).await;
-        let pool_migration_client = client_builder
+        let client = client_builder
             .build_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false, regtest_network)
             .await;
-        let pmc_taddr = get_base_address_macro!(pool_migration_client, "transparent");
-        let pmc_sapling = get_base_address_macro!(pool_migration_client, "sapling");
-        let pmc_unified = get_base_address_macro!(pool_migration_client, "unified");
+        let pmc_taddr = get_base_address_macro!(client, "transparent");
+        let pmc_sapling = get_base_address_macro!(client, "sapling");
+        let pmc_unified = get_base_address_macro!(client, "unified");
         // Ensure that the client has confirmed spendable funds
-        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &sapling_faucet, 3)
+        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &sapling_faucet, 1)
             .await
             .unwrap();
-        macro_rules! bump_and_check_pmc {
-        (o: $o:tt s: $s:tt t: $t:tt) => {
-            zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &pool_migration_client, 1).await.unwrap();
-            check_client_balances!(pool_migration_client, o:$o s:$s t:$t);
-        };
-    }
+        macro_rules! bump_and_check {
+            (o: $o:tt s: $s:tt t: $t:tt) => {
+                zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &client, 1).await.unwrap();
+                check_client_balances!(client, o:$o s:$s t:$t);
+            };
+        }
 
+        let mut test_dev_total_expected_fee = 0;
         // 1 pmc receives 50_000 transparent
-        //  # Expected Fees:
+        //  # Expected Fees to recipient:
         //    - legacy: 0
         //    - 317:    0
         from_inputs::quick_send(&sapling_faucet, vec![(&pmc_taddr, 50_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 0 s: 0 t: 50_000);
+        bump_and_check!(o: 0 s: 0 t: 50_000);
+        assert_eq!(test_dev_total_expected_fee, 0);
 
         // 2 pmc shields 50_000 transparent, to orchard paying 10_000 fee
-        //  # Expected Fees:
+        //  t -> o
+        //  # Expected Fees to recipient:
         //    - legacy: 10_000
-        //    - 317:    20_000
-        pool_migration_client.quick_shield().await.unwrap();
-        bump_and_check_pmc!(o: 40_000 s: 0 t: 0);
+        //    - 317:    15_000 1-orchard + 1-dummy + 1-transparent in
+        client.quick_shield().await.unwrap();
+        bump_and_check!(o: 35_000 s: 0 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 15_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
         // 3 pmc receives 50_000 sapling
-        //  # Expected Fees:
-        //    - legacy: 10_000
-        //    - 317:    20_000
+        //  # Expected Fees to recipient:
+        //    - legacy: 0
+        //    - 317:    0
         from_inputs::quick_send(&sapling_faucet, vec![(&pmc_sapling, 50_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 40_000 s: 50_000 t: 0);
+        bump_and_check!(o: 35_000 s: 50_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 0;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
         // 4 pmc shields 40_000 from sapling to orchard and pays 10_000 fee (should be 20_000 post zip317)
+        //  z -> o
         //  # Expected Fees:
         //    - legacy: 10_000
         //    - 317:    20_000
-        pool_migration_client.quick_shield().await.unwrap();
-        bump_and_check_pmc!(o: 80_000 s: 0 t: 0);
+        from_inputs::quick_send(&client, vec![(&pmc_unified, 30_000, None)])
+            .await
+            .unwrap();
+        bump_and_check!(o: 65_000 s: 0 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 5 Self send of 70_000 paying 10_000 fee
+        // 5 Self send of 55_000 paying 10_000 fee
+        //  o -> o
         //  # Expected Fees:
         //    - legacy: 10_000
         //    - 317:    10_000
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 70_000, None)])
+        from_inputs::quick_send(&client, vec![(&pmc_unified, 55_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 70_000 s: 0 t: 0);
+        bump_and_check!(o: 55_000 s: 0 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 10_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 4 to transparent and sapling from orchard
+        // 6 to transparent and sapling from orchard
+        //  o -> tz
         //  # Expected Fees:
         //    - legacy: 10_000
-        //    - 317:    5_000 for transparent + 10_000 for orchard + 10_000 for sapling == 25_000
+        //    - 317:    5_000 for transparent out + 10_000 for orchard + 10_000 for sapling == 25_000
         from_inputs::quick_send(
-            &pool_migration_client,
-            vec![(&pmc_taddr, 30_000, None), (&pmc_sapling, 30_000, None)],
+            &client,
+            vec![(&pmc_taddr, 10_000, None), (&pmc_sapling, 10_000, None)],
         )
         .await
         .unwrap();
-        bump_and_check_pmc!(o: 0 s: 30_000 t: 30_000);
+        bump_and_check!(o: 10_000 s: 10_000 t: 10_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 25_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 5 Shield transparent and sapling to orchard
+        // 7 Receipt
         //  # Expected Fees:
         //    - legacy: 10_000
         //    - 317:    disallowed (not *precisely*) BY 317...
-        pool_migration_client.quick_shield().await.unwrap();
-        bump_and_check_pmc!(o: 50_000 s: 0 t: 0);
+        from_inputs::quick_send(&sapling_faucet, vec![(&pmc_taddr, 500_000, None)])
+            .await
+            .unwrap();
+        bump_and_check!(o: 10_000 s: 10_000 t: 510_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 0;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 6 self send orchard to orchard
+        // 8 Shield transparent and sapling to orchard
+        //  t -> o
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    20_000 = 10_000 orchard and o-dummy + 10_000 (2 t-notes)
+        client.quick_shield().await.unwrap();
+        bump_and_check!(o: 500_000 s: 10_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
+
+        // 9 self o send orchard to orchard
+        //  o -> o
         //  # Expected Fees:
         //    - legacy: 10_000
         //    - 317:    10_000
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 20_000, None)])
+        from_inputs::quick_send(&client, vec![(&pmc_unified, 30_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 40_000 s: 0 t: 0);
+        bump_and_check!(o: 490_000 s: 10_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 10_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 7 Orchard to transparent self-send
+        // 10 Orchard and Sapling demote all to transparent self-send
+        //  oz -> t
         //  # Expected Fees:
         //    - legacy: 10_000
-        //    - 317:    (orchard = 10_000 + 5_000) 15_000
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_taddr, 20_000, None)])
+        //    - 317:    15_000 5-o (3 dust)- 10_000 orchard, 1 utxo 5_000 transparent
+        from_inputs::quick_send(&client, vec![(&pmc_taddr, 465_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 10_000 s: 0 t: 20_000);
+        bump_and_check!(o: 10_000 s: 10_000 t: 465_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 15_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 8 Shield transparent to orchard
-        // 7 Orchard to transparent self-send
+        // 10 transparent to transparent
+        // Very explicit catch of reject sending from transparent to other than Self Orchard
+        match from_inputs::quick_send(&client, vec![(&pmc_taddr, 1, None)]).await {
+            Ok(_) => panic!(),
+            Err(QuickSendError::ProposeSend(proposesenderror)) => match proposesenderror {
+                ProposeSendError::Proposal(insufficient) => match insufficient {
+                    zcash_client_backend::data_api::error::Error::DataSource(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::CommitmentTree(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::NoteSelection(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::Proposal(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::ProposalNotSupported => panic!(),
+                    zcash_client_backend::data_api::error::Error::KeyNotRecognized => panic!(),
+                    zcash_client_backend::data_api::error::Error::BalanceError(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::InsufficientFunds {
+                        available,
+                        required,
+                    } => {
+                        assert_eq!(available, NonNegativeAmount::from_u64(20_000).unwrap());
+                        assert_eq!(required, NonNegativeAmount::from_u64(25_001).unwrap());
+                    }
+                    zcash_client_backend::data_api::error::Error::ScanRequired => panic!(),
+                    zcash_client_backend::data_api::error::Error::Builder(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::MemoForbidden => panic!(),
+                    zcash_client_backend::data_api::error::Error::UnsupportedChangeType(_) => {
+                        panic!()
+                    }
+                    zcash_client_backend::data_api::error::Error::NoSupportedReceivers(_) => {
+                        panic!()
+                    }
+                    zcash_client_backend::data_api::error::Error::NoSpendingKey(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::NoteMismatch(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::AddressNotRecognized(_) => {
+                        panic!()
+                    }
+                },
+                ProposeSendError::TransactionRequestFailed(_) => panic!(),
+                ProposeSendError::ZeroValueSendAll => panic!(),
+                ProposeSendError::BalanceError(_) => panic!(),
+            },
+            _ => panic!(),
+        }
+        bump_and_check!(o: 10_000 s: 10_000 t: 465_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 0;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
+
+        // 11 transparent to sapling
+        //  t -> z
+        // 10 transparent to transparent
+        // Very explicit catch of reject sending from transparent to other than Self Orchard
+        match from_inputs::quick_send(&client, vec![(&pmc_sapling, 50_000, None)]).await {
+            Ok(_) => panic!(),
+            Err(QuickSendError::ProposeSend(proposesenderror)) => match proposesenderror {
+                ProposeSendError::Proposal(insufficient) => match insufficient {
+                    zcash_client_backend::data_api::error::Error::InsufficientFunds {
+                        available,
+                        required,
+                    } => {
+                        assert_eq!(available, NonNegativeAmount::from_u64(20_000).unwrap());
+                        assert_eq!(required, NonNegativeAmount::from_u64(70_000).unwrap());
+                    }
+                    _ => {
+                        panic!()
+                    }
+                },
+                _ => panic!(),
+            },
+            _ => panic!(),
+        }
+        // End of 11 no change
+        bump_and_check!(o: 10_000 s: 10_000 t: 465_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 0;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
+
+        // 12 Orchard and Sapling demote all to transparent self-send
+        //  t -> o
         //  # Expected Fees:
         //    - legacy: 10_000
-        //    - 317:    disallowed
-        pool_migration_client.quick_shield().await.unwrap();
-        bump_and_check_pmc!(o: 20_000 s: 0 t: 0);
+        //    - 317:    15_000 1t and 2o
+        client.quick_shield().await.unwrap();
+        bump_and_check!(o: 460_000 s: 10_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 15_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 6 sapling and orchard to orchard
-        from_inputs::quick_send(&sapling_faucet, vec![(&pmc_sapling, 20_000, None)])
+        // 13 Orchard and Sapling demote all to transparent self-send
+        //  o -> z
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    20_000 2o and 2s
+        from_inputs::quick_send(&client, vec![(&pmc_sapling, 10_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 20_000 s: 20_000 t: 0);
+        bump_and_check!(o: 430_000 s: 20_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 30_000, None)])
+        // 14 Orchard and Sapling demote all to transparent self-send
+        //  o -> o
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    10_000
+        from_inputs::quick_send(&client, vec![(&pmc_unified, 20_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 30_000 s: 0 t: 0);
+        bump_and_check!(o: 420_000 s: 20_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 10_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 7 tzo --> o
-        from_inputs::quick_send(
-            &sapling_faucet,
-            vec![(&pmc_taddr, 20_000, None), (&pmc_sapling, 20_000, None)],
-        )
-        .await
-        .unwrap();
-        bump_and_check_pmc!(o: 30_000 s: 20_000 t: 20_000);
-
-        pool_migration_client.quick_shield().await.unwrap();
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 40_000, None)])
+        // 14 Orchard and Sapling demote all to transparent self-send
+        //  zo -> o
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    20_000
+        from_inputs::quick_send(&client, vec![(&pmc_sapling, 400_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 50_000 s: 0 t: 0);
+        bump_and_check!(o: 10_000 s: 410_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // Send from Sapling into empty Orchard pool
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_sapling, 40_000, None)])
+        // 15 Orchard and Sapling demote all to transparent self-send
+        //  z -> z
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    20_000  this transfer must require 4 sapling notes
+        from_inputs::quick_send(&client, vec![(&pmc_sapling, 380_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 0 s: 40_000 t: 0);
+        bump_and_check!(o: 10_000 s: 390_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 30_000, None)])
-            .await
-            .unwrap();
-        bump_and_check_pmc!(o: 30_000 s: 0 t: 0);
-        let mut total_value_to_addrs_iter = pool_migration_client
-            .do_total_value_to_address()
-            .await
-            .0
-            .into_iter();
-        assert_eq!(
-            total_value_to_addrs_iter.next(),
-            Some((String::from("fee"), u64::from((MINIMUM_FEE * 13).unwrap())))
-        );
+        let total_fee = fees(&client).await;
+        assert_eq!(total_fee, test_dev_total_expected_fee);
+        let mut total_value_to_addrs_iter = client.do_total_value_to_address().await.0.into_iter();
+        let from_finsight = total_value_to_addrs_iter.next().unwrap().1;
+        assert_eq!(from_finsight, total_fee);
         assert!(total_value_to_addrs_iter.next().is_none());
     }
     #[tokio::test]

--- a/libtonode-tests/tests/shield_transparent.rs
+++ b/libtonode-tests/tests/shield_transparent.rs
@@ -15,7 +15,7 @@ async fn shield_transparent() {
         serde_json::to_string_pretty(&faucet.do_balance().await).unwrap(),
         serde_json::to_string_pretty(&recipient.do_balance().await).unwrap(),
     );
-    let proposal = from_inputs::send(
+    let proposal = from_inputs::quick_send(
         &faucet,
         vec![(
             &get_base_address_macro!(recipient, "transparent"),

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -423,6 +423,14 @@ pub mod fixtures {
                 .await,
             expected_value_from_transaction_1 - expected_debit_from_transaction_2
         );
+        let received_change_from_transaction_2 = secondary
+            .query_sum_value(OutputQuery {
+                spend_status: OutputSpendStatusQuery::only_unspent(),
+                pools: OutputPoolQuery::one_pool(Shielded(Orchard)),
+            })
+            .await;
+        // if 10_000 or more change incoming, would have used a smaller note
+        assert!(received_change_from_transaction_2 < 10_000);
 
         // with_assertions::propose_send_bump_sync_recipient(
         //     &mut environment,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -384,6 +384,16 @@ pub mod fixtures {
             expected_fee_for_transaction_1
         );
 
+        assert_eq!(
+            secondary
+                .query_sum_value(OutputQuery {
+                    spend_status: OutputSpendStatusQuery::only_unspent(),
+                    pools: OutputPoolQuery::one_pool(Shielded(Sapling)),
+                })
+                .await,
+            expected_value_from_transaction_1
+        );
+
         // toDo: these depend on the number_of_notes and value_from_transaction_2
         let expected_inputs_for_transaction_2 = 2;
         let expected_orchard_contribution_for_transaction_2 = 2;

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -412,6 +412,18 @@ pub mod fixtures {
             expected_fee_for_transaction_2
         );
 
+        let expected_debit_from_transaction_2 =
+            expected_fee_for_transaction_2 + value_from_transaction_2;
+        assert_eq!(
+            secondary
+                .query_sum_value(OutputQuery {
+                    spend_status: OutputSpendStatusQuery::only_unspent(),
+                    pools: OutputPoolQuery::shielded(),
+                })
+                .await,
+            expected_value_from_transaction_1 - expected_debit_from_transaction_2
+        );
+
         // with_assertions::propose_send_bump_sync_recipient(
         //     &mut environment,
         //     &primary,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -396,7 +396,7 @@ pub mod fixtures {
 
         let expected_orchard_contribution_for_transaction_2 = 2;
 
-        // toDo: these depend on the number_of_notes and value_from_transaction_2
+        // calculate what will be spent
         let mut expected_highest_unselected = 10_000 * number_of_notes;
         let mut expected_inputs_for_transaction_2 = 0;
         let mut max_unselected_value_for_transaction_2: i64 =
@@ -413,7 +413,7 @@ pub mod fixtures {
                 break;
             }
             if expected_highest_unselected <= 0 {
-                // did not meet target. expect failure
+                // did not meet target. expect error on send
                 break;
             }
         }
@@ -452,5 +452,16 @@ pub mod fixtures {
             .await;
         // if 10_000 or more change, would have used a smaller note
         assert!(received_change_from_transaction_2 < 10_000);
+
+        assert_eq!(
+            secondary
+                .query_for_ids(OutputQuery {
+                    spend_status: OutputSpendStatusQuery::only_spent(),
+                    pools: OutputPoolQuery::one_pool(Shielded(Sapling)),
+                })
+                .await
+                .len(),
+            expected_inputs_for_transaction_2 as usize
+        );
     }
 }

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -361,7 +361,7 @@ pub mod fixtures {
     {
         // toDo: proptest different values for these first two variables
         let number_of_notes = 4;
-        let value_from_transaction_2: u64 = 65_000;
+        let value_from_transaction_2: u64 = 40_000;
 
         let transaction_1_values = (1..=number_of_notes).map(|n| n * 10_000);
 
@@ -388,12 +388,13 @@ pub mod fixtures {
             expected_fee_for_transaction_1
         );
 
-        // toDo: these depend on the number_of_notes
-        let expected_inputs_for_transaction_2 = 3;
+        // toDo: these depend on the number_of_notes and value_from_transaction_2
+        let expected_inputs_for_transaction_2 = 2;
         let expected_orchard_contribution_for_transaction_2 = 2;
         let expected_fee_for_transaction_2 = (expected_inputs_for_transaction_2
             + expected_orchard_contribution_for_transaction_2)
             * MARGINAL_FEE.into_u64();
+        // the second client selects notes to cover the transaction.
         assert_eq!(
             with_assertions::propose_send_bump_sync_recipient(
                 &mut environment,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -359,19 +359,32 @@ pub mod fixtures {
     where
         CC: ConductChain,
     {
-        let mut environment = CC::setup().await;
+        let number_of_notes = 4;
 
-        let primary = environment.fund_client_orchard(200_000).await;
+        let transaction_1_sends = (1..=number_of_notes).map(|n| n * 10_000);
+
+        let expected_fee_for_transaction_1 = number_of_notes * 2 * MARGINAL_FEE.into_u64();
+        // let expected_funds_from_transaction_1 = oeui.map(x);
+
+        let mut environment = CC::setup().await;
+        let primary = environment
+            .fund_client_orchard(expected_fee_for_transaction_1)
+            .await;
         let secondary = environment.create_client().await;
 
         // Send n=4 transfers in increasing 10_000 zat increments
-        with_assertions::propose_send_bump_sync_recipient(
-            &mut environment,
-            &primary,
-            &secondary,
-            (1..=4).map(|n| (Shielded(Sapling), n * 10_000)).collect(),
-        )
-        .await;
+        assert_eq!(
+            with_assertions::propose_send_bump_sync_recipient(
+                &mut environment,
+                &primary,
+                &secondary,
+                transaction_1_sends
+                    .map(|value| (Shielded(Sapling), value))
+                    .collect()
+            )
+            .await,
+            number_of_notes * 2 * MARGINAL_FEE.into_u64()
+        );
 
         with_assertions::propose_send_bump_sync_recipient(
             &mut environment,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -361,34 +361,26 @@ pub mod fixtures {
     {
         let mut environment = CC::setup().await;
 
-        let primary = environment.fund_client_orchard(100_000).await;
+        let primary = environment.fund_client_orchard(200_000).await;
         let secondary = environment.create_client().await;
 
-        // Send three transfers in increasing 10_000 zat increments
+        // Send n=4 transfers in increasing 10_000 zat increments
         with_assertions::propose_send_bump_sync_recipient(
             &mut environment,
             &primary,
             &secondary,
-            (1..=3).map(|n| (Shielded(Sapling), n * 10_000)).collect(),
+            (1..=4).map(|n| (Shielded(Sapling), n * 10_000)).collect(),
+        )
+        .await;
+
+        with_assertions::propose_send_bump_sync_recipient(
+            &mut environment,
+            &primary,
+            &secondary,
+            vec![(Shielded(Orchard), 40_000)],
         )
         .await;
         /*
-        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &recipient, 5)
-            .await
-            .unwrap();
-        // We know that the largest single note that 2 received from 1 was 30_000, for 2 to send
-        // 30_000 back to 1 it will have to collect funds from two notes to pay the full 30_000
-        // plus the transaction fee.
-        from_inputs::quick_send(
-            &recipient,
-            vec![(
-                &get_base_address_macro!(faucet, "unified"),
-                30_000,
-                Some("Sending back, should have 2 inputs"),
-            )],
-        )
-        .await
-        .unwrap();
         let client_2_notes = recipient.do_list_notes(false).await;
         // The 30_000 zat note to cover the value, plus another for the tx-fee.
         let first_value = client_2_notes["pending_sapling_notes"][0]["value"]

--- a/zingo-testutils/src/lightclient.rs
+++ b/zingo-testutils/src/lightclient.rs
@@ -29,6 +29,21 @@ pub async fn get_base_address(client: &LightClient, pooltype: PoolType) -> Strin
         }
     }
 }
+/// Get the total fees paid by a given client (assumes 1 capability per client).
+pub async fn get_fees_paid_by_client(client: &LightClient) -> u64 {
+    client
+        .list_txsummaries()
+        .await
+        .into_iter()
+        .filter_map(|x| {
+            if let zingolib::wallet::data::summaries::ValueTransferKind::Fee { amount } = x.kind {
+                Some(amount)
+            } else {
+                None
+            }
+        })
+        .sum::<u64>()
+}
 /// Helpers to provide raw_receivers to lightclients for send and shield, etc.
 pub mod from_inputs {
     use zcash_client_backend::PoolType;


### PR DESCRIPTION
I think we need to understand why this test is failing.   It's to do with how we depend on a transaction record to make changes to a transaction to create the transaction record..   in other words the circular `pending` bug.