### PR TITLE
Improve note spendability short circuited

### DIFF
--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -27,7 +27,7 @@ use crate::{
     sync::{self, ScanPriority, ScanRange},
     wallet::{
         ScanTarget, WalletBlock,
-        traits::{SyncBlocks, SyncNullifiers, SyncWallet},
+        traits::{SyncBlocks, SyncNullifiers, SyncTransactions, SyncWallet},
     },
 };
 
@@ -203,7 +203,7 @@ where
         nullifier_map_limit_exceeded: bool,
     ) -> Result<(), SyncError<W::Error>>
     where
-        W: SyncWallet + SyncBlocks + SyncNullifiers,
+        W: SyncWallet + SyncBlocks + SyncNullifiers + SyncTransactions,
     {
         self.check_batcher_error()?;
 
@@ -282,7 +282,7 @@ where
         nullifier_map_limit_exceeded: bool,
     ) -> Result<(), W::Error>
     where
-        W: SyncWallet + SyncBlocks + SyncNullifiers,
+        W: SyncWallet + SyncBlocks + SyncNullifiers + SyncTransactions,
     {
         let batcher = self.batcher.as_ref().expect("batcher should be running");
         if !batcher.is_batching() {

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -585,6 +585,7 @@ fn select_scan_range(
     consensus_parameters: &impl consensus::Parameters,
     sync_state: &mut SyncState,
     nullifier_map_limit_exceeded: bool,
+    wallet_transactions: &HashMap<TxId, WalletTransaction>,
 ) -> Option<ScanRange> {
     let (first_unscanned_index, first_unscanned_range) = sync_state
         .scan_ranges
@@ -593,6 +594,21 @@ fn select_scan_range(
         .find(|(_, scan_range)| scan_range.priority() != ScanPriority::Scanned)?;
     let (selected_index, selected_scan_range) =
         if first_unscanned_range.priority() == ScanPriority::ScannedWithoutMapping {
+            // if no unspent notes depend on this range, promote directly to Scanned and re-select.
+            // this cascades through consecutive no-op ScannedWithoutMapping ranges without any network fetch.
+            if !notes_require_nullifier_refetch(wallet_transactions, first_unscanned_range.block_range()) {
+                sync_state.scan_ranges[first_unscanned_index] = ScanRange::from_parts(
+                    first_unscanned_range.block_range().clone(),
+                    ScanPriority::Scanned,
+                );
+                return select_scan_range(
+                    consensus_parameters,
+                    sync_state,
+                    nullifier_map_limit_exceeded,
+                    wallet_transactions,
+                );
+            }
+
             // prioritise re-fetching the nullifiers when a range with priority `ScannedWithoutMapping` is the first
             // unscanned range.
             // the `first_unscanned_range` may have `Scanning` priority here as we must select a `ScannedWithoutMapping` range only when all ranges below are `Scanned`. if a `ScannedwithoutMapping` range is selected and completes *before* a lower range that is currently `Scanning`, the nullifiers will need to be discarded and re-fetched afterwards. so this avoids a race condition that results in a sync inefficiency.

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -21,7 +21,8 @@ use crate::{
     scan::task::ScanTask,
     sync::ScanRange,
     wallet::{
-        InitialSyncState, ScanTarget, SyncState, TreeBounds, WalletTransaction,
+        InitialSyncState, NoteInterface, OrchardNote, SaplingNote, ScanTarget, SyncState,
+        TreeBounds, WalletTransaction,
         traits::{SyncBlocks, SyncNullifiers, SyncWallet},
     },
 };
@@ -535,6 +536,35 @@ fn split_out_scan_range(
     }
 
     split_ranges
+}
+
+/// Returns `true` if any unspent note of type `N` has a `refetch_nullifier_ranges` entry overlapping `range`.
+fn any_note_requires_refetch<N: NoteInterface>(
+    wallet_transactions: &HashMap<TxId, WalletTransaction>,
+    range: &Range<BlockHeight>,
+) -> bool {
+    wallet_transactions.values().any(|tx| {
+        N::transaction_outputs(tx).iter().any(|note| {
+            note.spending_transaction().is_none()
+                && note
+                    .refetch_nullifier_ranges()
+                    .iter()
+                    .any(|r| r.start < range.end && range.start < r.end)
+        })
+    })
+}
+
+/// Returns `true` if any unspent shielded note has a `refetch_nullifier_ranges` entry overlapping `range`,
+/// meaning nullifiers from that range must be re-fetched for final spend detection.
+///
+/// Returns `false` if no notes depend on this range, allowing it to be promoted directly from
+/// `ScannedWithoutMapping` to `Scanned` without a network fetch.
+fn notes_require_nullifier_refetch(
+    wallet_transactions: &HashMap<TxId, WalletTransaction>,
+    range: &Range<BlockHeight>,
+) -> bool {
+    any_note_requires_refetch::<SaplingNote>(wallet_transactions, range)
+        || any_note_requires_refetch::<OrchardNote>(wallet_transactions, range)
 }
 
 /// Selects and prepares the next scan range for scanning.

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -23,7 +23,7 @@ use crate::{
     wallet::{
         InitialSyncState, NoteInterface, OrchardNote, SaplingNote, ScanTarget, SyncState,
         TreeBounds, WalletTransaction,
-        traits::{SyncBlocks, SyncNullifiers, SyncWallet},
+        traits::{SyncBlocks, SyncNullifiers, SyncTransactions, SyncWallet},
     },
 };
 
@@ -538,39 +538,51 @@ fn split_out_scan_range(
     split_ranges
 }
 
-/// Returns `true` if any unspent note of type `N` has a `refetch_nullifier_ranges` entry overlapping `range`.
-fn any_note_requires_refetch<N: NoteInterface>(
+/// Collects all `refetch_nullifier_ranges` from unspent notes of type `N` across all wallet transactions.
+fn collect_active_refetch_ranges<N: NoteInterface>(
     wallet_transactions: &HashMap<TxId, WalletTransaction>,
-    scanned_wo_map_range: &Range<BlockHeight>,
-) -> bool {
-    wallet_transactions.values().any(|tx| {
-        N::transaction_outputs(tx).iter().any(|note| {
-            note.spending_transaction().is_none()
-                && note
-                    .refetch_nullifier_ranges()
-                    .iter()
-                    // a note depends on this range if any of its refetch ranges overlap:
-                    // partial overlap from below, partial overlap from above,
-                    // full containment in either direction, or exact match.
-                    .any(|refetch_range| {
-                        refetch_range.start < scanned_wo_map_range.end
-                            && scanned_wo_map_range.start < refetch_range.end
-                    })
+) -> Vec<Range<BlockHeight>> {
+    wallet_transactions
+        .values()
+        .flat_map(|tx| {
+            N::transaction_outputs(tx)
+                .iter()
+                .filter(|note| note.spending_transaction().is_none())
+                .flat_map(|note| note.refetch_nullifier_ranges().iter().cloned())
         })
-    })
+        .collect()
 }
 
-/// Returns `true` if any unspent shielded note has a `refetch_nullifier_ranges` entry overlapping `range`,
+/// Collects all `refetch_nullifier_ranges` from unspent shielded notes.
+///
+/// The result is owned data that can be passed into [`select_scan_range`] without holding an
+/// immutable borrow on the wallet, avoiding a borrow conflict with `&mut SyncState`.
+fn active_refetch_ranges(
+    wallet_transactions: &HashMap<TxId, WalletTransaction>,
+) -> Vec<Range<BlockHeight>> {
+    let mut ranges = collect_active_refetch_ranges::<SaplingNote>(wallet_transactions);
+    ranges.extend(collect_active_refetch_ranges::<OrchardNote>(
+        wallet_transactions,
+    ));
+    ranges
+}
+
+/// Returns `true` if any active refetch range overlaps `scanned_wo_map_range`,
 /// meaning nullifiers from that range must be re-fetched for final spend detection.
 ///
 /// Returns `false` if no notes depend on this range, allowing it to be promoted directly from
 /// `ScannedWithoutMapping` to `Scanned` without a network fetch.
-fn notes_require_nullifier_refetch(
-    wallet_transactions: &HashMap<TxId, WalletTransaction>,
+fn any_refetch_range_overlaps(
+    active_refetch_ranges: &[Range<BlockHeight>],
     scanned_wo_map_range: &Range<BlockHeight>,
 ) -> bool {
-    any_note_requires_refetch::<SaplingNote>(wallet_transactions, scanned_wo_map_range)
-        || any_note_requires_refetch::<OrchardNote>(wallet_transactions, scanned_wo_map_range)
+    active_refetch_ranges.iter().any(|refetch_range| {
+        // a note depends on this range if any of its refetch ranges overlap:
+        // partial overlap from below, partial overlap from above,
+        // full containment in either direction, or exact match.
+        refetch_range.start < scanned_wo_map_range.end
+            && scanned_wo_map_range.start < refetch_range.end
+    })
 }
 
 /// Selects and prepares the next scan range for scanning.
@@ -585,7 +597,7 @@ fn select_scan_range(
     consensus_parameters: &impl consensus::Parameters,
     sync_state: &mut SyncState,
     nullifier_map_limit_exceeded: bool,
-    wallet_transactions: &HashMap<TxId, WalletTransaction>,
+    active_refetch_ranges: &[Range<BlockHeight>],
 ) -> Option<ScanRange> {
     let (first_unscanned_index, first_unscanned_range) = sync_state
         .scan_ranges
@@ -596,7 +608,7 @@ fn select_scan_range(
         if first_unscanned_range.priority() == ScanPriority::ScannedWithoutMapping {
             // if no unspent notes depend on this range, promote directly to Scanned and re-select.
             // this cascades through consecutive no-op ScannedWithoutMapping ranges without any network fetch.
-            if !notes_require_nullifier_refetch(wallet_transactions, first_unscanned_range.block_range()) {
+            if !any_refetch_range_overlaps(active_refetch_ranges, first_unscanned_range.block_range()) {
                 sync_state.scan_ranges[first_unscanned_index] = ScanRange::from_parts(
                     first_unscanned_range.block_range().clone(),
                     ScanPriority::Scanned,
@@ -605,7 +617,7 @@ fn select_scan_range(
                     consensus_parameters,
                     sync_state,
                     nullifier_map_limit_exceeded,
-                    wallet_transactions,
+                    active_refetch_ranges,
                 );
             }
 
@@ -712,12 +724,14 @@ pub(crate) fn create_scan_task<W>(
     nullifier_map_limit_exceeded: bool,
 ) -> Result<Option<ScanTask>, W::Error>
 where
-    W: SyncWallet + SyncBlocks + SyncNullifiers,
+    W: SyncWallet + SyncBlocks + SyncNullifiers + SyncTransactions,
 {
+    let active_refetch_ranges = active_refetch_ranges(wallet.get_wallet_transactions()?);
     if let Some(selected_range) = select_scan_range(
         consensus_parameters,
         wallet.get_sync_state_mut()?,
         nullifier_map_limit_exceeded,
+        &active_refetch_ranges,
     ) {
         if selected_range.priority() == ScanPriority::ScannedWithoutMapping {
             // all continuity checks and scanning is already complete, the scan worker will only re-fetch the nullifiers

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -604,68 +604,69 @@ fn select_scan_range(
         .iter()
         .enumerate()
         .find(|(_, scan_range)| scan_range.priority() != ScanPriority::Scanned)?;
-    let (selected_index, selected_scan_range) =
-        if first_unscanned_range.priority() == ScanPriority::ScannedWithoutMapping {
-            // if no unspent notes depend on this range, promote directly to Scanned and re-select.
-            // this cascades through consecutive no-op ScannedWithoutMapping ranges without any network fetch.
-            if !any_refetch_range_overlaps(active_refetch_ranges, first_unscanned_range.block_range()) {
-                sync_state.scan_ranges[first_unscanned_index] = ScanRange::from_parts(
-                    first_unscanned_range.block_range().clone(),
-                    ScanPriority::Scanned,
-                );
-                return select_scan_range(
-                    consensus_parameters,
-                    sync_state,
-                    nullifier_map_limit_exceeded,
-                    active_refetch_ranges,
-                );
-            }
+    let (selected_index, selected_scan_range) = if first_unscanned_range.priority()
+        == ScanPriority::ScannedWithoutMapping
+    {
+        // if no unspent notes depend on this range, promote directly to Scanned and re-select.
+        // this cascades through consecutive no-op ScannedWithoutMapping ranges without any network fetch.
+        if !any_refetch_range_overlaps(active_refetch_ranges, first_unscanned_range.block_range()) {
+            sync_state.scan_ranges[first_unscanned_index] = ScanRange::from_parts(
+                first_unscanned_range.block_range().clone(),
+                ScanPriority::Scanned,
+            );
+            return select_scan_range(
+                consensus_parameters,
+                sync_state,
+                nullifier_map_limit_exceeded,
+                active_refetch_ranges,
+            );
+        }
 
-            // prioritise re-fetching the nullifiers when a range with priority `ScannedWithoutMapping` is the first
-            // unscanned range.
-            // the `first_unscanned_range` may have `Scanning` priority here as we must select a `ScannedWithoutMapping` range only when all ranges below are `Scanned`. if a `ScannedwithoutMapping` range is selected and completes *before* a lower range that is currently `Scanning`, the nullifiers will need to be discarded and re-fetched afterwards. so this avoids a race condition that results in a sync inefficiency.
-            (first_unscanned_index, first_unscanned_range.clone())
-        } else {
-            // scan ranges are sorted from lowest to highest priority.
-            // scan ranges with the same priority are sorted in block height order.
-            // the highest priority scan range is then selected from the end of the list, the highest priority with highest
-            // starting block height.
-            // if the highest priority is `Historic` the range with the lowest starting block height is selected instead.
-            // if nullifiers are not being mapped to the wallet's main nullifier map due to performance constraints
-            // (`nullifier_map_limit_exceeded` is set `true`) then the range with the highest priority and lowest starting block
-            // height is selected to allow notes to be spendable quickly on rescan, otherwise spends would not be detected as nullifiers will be temporarily discarded.
-            // TODO: add this documentation of performance levels and order of scanning to pepper-sync doc comments
-            let mut scan_ranges_priority_sorted: Vec<(usize, ScanRange)> =
-                sync_state.scan_ranges.iter().cloned().enumerate().collect();
-            if nullifier_map_limit_exceeded {
-                scan_ranges_priority_sorted
-                    .sort_by(|(_, a), (_, b)| b.block_range().start.cmp(&a.block_range().start));
-            }
-            scan_ranges_priority_sorted.sort_by_key(|(_, scan_range)| scan_range.priority());
-
+        // prioritise re-fetching the nullifiers when a range with priority `ScannedWithoutMapping` is the first
+        // unscanned range.
+        // the `first_unscanned_range` may have `Scanning` priority here as we must select a `ScannedWithoutMapping` range only when all ranges below are `Scanned`. if a `ScannedwithoutMapping` range is selected and completes *before* a lower range that is currently `Scanning`, the nullifiers will need to be discarded and re-fetched afterwards. so this avoids a race condition that results in a sync inefficiency.
+        (first_unscanned_index, first_unscanned_range.clone())
+    } else {
+        // scan ranges are sorted from lowest to highest priority.
+        // scan ranges with the same priority are sorted in block height order.
+        // the highest priority scan range is then selected from the end of the list, the highest priority with highest
+        // starting block height.
+        // if the highest priority is `Historic` the range with the lowest starting block height is selected instead.
+        // if nullifiers are not being mapped to the wallet's main nullifier map due to performance constraints
+        // (`nullifier_map_limit_exceeded` is set `true`) then the range with the highest priority and lowest starting block
+        // height is selected to allow notes to be spendable quickly on rescan, otherwise spends would not be detected as nullifiers will be temporarily discarded.
+        // TODO: add this documentation of performance levels and order of scanning to pepper-sync doc comments
+        let mut scan_ranges_priority_sorted: Vec<(usize, ScanRange)> =
+            sync_state.scan_ranges.iter().cloned().enumerate().collect();
+        if nullifier_map_limit_exceeded {
             scan_ranges_priority_sorted
-                .last()
-                .map(|(index, highest_priority_range)| {
-                    if highest_priority_range.priority() == ScanPriority::Historic {
-                        if nullifier_map_limit_exceeded {
-                            // in this case, scan ranges are already sorted from highest to lowest and we are selecting
-                            // the last range (lowest range with historic priority)
-                            (*index, highest_priority_range.clone())
-                        } else {
-                            // in this case, scan ranges are sorted from lowest to highest and we are selecting
-                            // the lowest range with historic priority
-                            scan_ranges_priority_sorted
-                                .iter()
-                                .find(|(_, range)| range.priority() == ScanPriority::Historic)
-                                .expect("range with Historic priority exists in this scope")
-                                .clone()
-                        }
-                    } else {
-                        // select the last range in the list
+                .sort_by(|(_, a), (_, b)| b.block_range().start.cmp(&a.block_range().start));
+        }
+        scan_ranges_priority_sorted.sort_by_key(|(_, scan_range)| scan_range.priority());
+
+        scan_ranges_priority_sorted
+            .last()
+            .map(|(index, highest_priority_range)| {
+                if highest_priority_range.priority() == ScanPriority::Historic {
+                    if nullifier_map_limit_exceeded {
+                        // in this case, scan ranges are already sorted from highest to lowest and we are selecting
+                        // the last range (lowest range with historic priority)
                         (*index, highest_priority_range.clone())
+                    } else {
+                        // in this case, scan ranges are sorted from lowest to highest and we are selecting
+                        // the lowest range with historic priority
+                        scan_ranges_priority_sorted
+                            .iter()
+                            .find(|(_, range)| range.priority() == ScanPriority::Historic)
+                            .expect("range with Historic priority exists in this scope")
+                            .clone()
                     }
-                })?
-        };
+                } else {
+                    // select the last range in the list
+                    (*index, highest_priority_range.clone())
+                }
+            })?
+    };
 
     let selected_priority = selected_scan_range.priority();
 

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -541,7 +541,7 @@ fn split_out_scan_range(
 /// Returns `true` if any unspent note of type `N` has a `refetch_nullifier_ranges` entry overlapping `range`.
 fn any_note_requires_refetch<N: NoteInterface>(
     wallet_transactions: &HashMap<TxId, WalletTransaction>,
-    range: &Range<BlockHeight>,
+    scanned_wo_map_range: &Range<BlockHeight>,
 ) -> bool {
     wallet_transactions.values().any(|tx| {
         N::transaction_outputs(tx).iter().any(|note| {
@@ -549,7 +549,13 @@ fn any_note_requires_refetch<N: NoteInterface>(
                 && note
                     .refetch_nullifier_ranges()
                     .iter()
-                    .any(|r| r.start < range.end && range.start < r.end)
+                    // a note depends on this range if any of its refetch ranges overlap:
+                    // partial overlap from below, partial overlap from above,
+                    // full containment in either direction, or exact match.
+                    .any(|refetch_range| {
+                        refetch_range.start < scanned_wo_map_range.end
+                            && scanned_wo_map_range.start < refetch_range.end
+                    })
         })
     })
 }
@@ -561,10 +567,10 @@ fn any_note_requires_refetch<N: NoteInterface>(
 /// `ScannedWithoutMapping` to `Scanned` without a network fetch.
 fn notes_require_nullifier_refetch(
     wallet_transactions: &HashMap<TxId, WalletTransaction>,
-    range: &Range<BlockHeight>,
+    scanned_wo_map_range: &Range<BlockHeight>,
 ) -> bool {
-    any_note_requires_refetch::<SaplingNote>(wallet_transactions, range)
-        || any_note_requires_refetch::<OrchardNote>(wallet_transactions, range)
+    any_note_requires_refetch::<SaplingNote>(wallet_transactions, scanned_wo_map_range)
+        || any_note_requires_refetch::<OrchardNote>(wallet_transactions, scanned_wo_map_range)
 }
 
 /// Selects and prepares the next scan range for scanning.

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::{Read, Write},
+    ops::Range,
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -483,6 +484,31 @@ impl<N, Nf: Copy> WalletNote<N, Nf> {
     }
 }
 
+fn read_refetch_nullifier_ranges(
+    reader: &mut impl Read,
+    version: u8,
+) -> std::io::Result<Vec<Range<BlockHeight>>> {
+    if version >= 1 {
+        Vector::read(reader, |r| {
+            let start = r.read_u32::<LittleEndian>()?;
+            let end = r.read_u32::<LittleEndian>()?;
+            Ok(BlockHeight::from_u32(start)..BlockHeight::from_u32(end))
+        })
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+fn write_refetch_nullifier_ranges(
+    writer: &mut impl Write,
+    ranges: &[Range<BlockHeight>],
+) -> std::io::Result<()> {
+    Vector::write(writer, ranges, |w, range| {
+        w.write_u32::<LittleEndian>(range.start.into())?;
+        w.write_u32::<LittleEndian>(range.end.into())
+    })
+}
+
 impl SaplingNote {
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
@@ -557,17 +583,7 @@ impl SaplingNote {
         })?;
 
         let spending_transaction = Optional::read(&mut reader, TxId::read)?;
-
-        let refetch_nullifier_ranges = if version >= 1 {
-            Vector::read(&mut reader, |r| {
-                let start = r.read_u32::<LittleEndian>()?;
-                let end = r.read_u32::<LittleEndian>()?;
-
-                Ok(BlockHeight::from_u32(start)..BlockHeight::from_u32(end))
-            })?
-        } else {
-            Vec::new()
-        };
+        let refetch_nullifier_ranges = read_refetch_nullifier_ranges(&mut reader, version)?;
 
         Ok(Self {
             output_id: OutputId::new(txid, output_index),
@@ -616,10 +632,7 @@ impl SaplingNote {
             txid.write(w)
         })?;
 
-        Vector::write(&mut writer, &self.refetch_nullifier_ranges, |w, range| {
-            w.write_u32::<LittleEndian>(range.start.into())?;
-            w.write_u32::<LittleEndian>(range.end.into())
-        })
+        write_refetch_nullifier_ranges(&mut writer, &self.refetch_nullifier_ranges)
     }
 }
 
@@ -680,17 +693,7 @@ impl OrchardNote {
         })?;
 
         let spending_transaction = Optional::read(&mut reader, TxId::read)?;
-
-        let refetch_nullifier_ranges = if version >= 1 {
-            Vector::read(&mut reader, |r| {
-                let start = r.read_u32::<LittleEndian>()?;
-                let end = r.read_u32::<LittleEndian>()?;
-
-                Ok(BlockHeight::from_u32(start)..BlockHeight::from_u32(end))
-            })?
-        } else {
-            Vec::new()
-        };
+        let refetch_nullifier_ranges = read_refetch_nullifier_ranges(&mut reader, version)?;
 
         Ok(Self {
             output_id: OutputId::new(txid, output_index),
@@ -731,10 +734,7 @@ impl OrchardNote {
             txid.write(w)
         })?;
 
-        Vector::write(&mut writer, &self.refetch_nullifier_ranges, |w, range| {
-            w.write_u32::<LittleEndian>(range.start.into())?;
-            w.write_u32::<LittleEndian>(range.end.into())
-        })
+        write_refetch_nullifier_ranges(&mut writer, &self.refetch_nullifier_ranges)
     }
 }
 

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -1,11 +1,8 @@
 //! Balance methods and types for `crate::wallet::LightWallet`.
 
-use pepper_sync::{
-    sync::ScanPriority,
-    wallet::{
-        KeyIdInterface, NoteInterface, OrchardNote, OutputInterface, SaplingNote, TransparentCoin,
-        WalletTransaction,
-    },
+use pepper_sync::wallet::{
+    KeyIdInterface, NoteInterface, OrchardNote, OutputInterface, SaplingNote, TransparentCoin,
+    WalletTransaction,
 };
 use zcash_client_backend::data_api::WalletRead;
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
@@ -502,26 +499,12 @@ impl LightWallet {
                     && transaction.status().get_height() <= anchor_height
                     && note.position().is_some()
                     && self.can_build_witness::<N>(transaction.status().get_height(), anchor_height)
-                    && if include_potentially_spent_notes {
-                        true
-                    } else {
-                        // checks all ranges above the note height are scanned and that the nullifiers were re-fetched
-                        // if any of these ranges discarded the nullifiers *before* the note was scanned (due to memory constraints).
-                        transaction.status().get_height() >= spend_horizon
-                            && note.refetch_nullifier_ranges().iter().all(
-                                |refetch_nullifier_range| {
-                                    self.sync_state.scan_ranges().iter().any(|scan_range| {
-                                        scan_range.priority() == ScanPriority::Scanned
-                                            && scan_range
-                                                .block_range()
-                                                .contains(&refetch_nullifier_range.start)
-                                            && scan_range
-                                                .block_range()
-                                                .contains(&(refetch_nullifier_range.end - 1))
-                                    })
-                                },
-                            )
-                    }
+                    && (include_potentially_spent_notes
+                        || self.note_spends_confirmed(
+                            transaction.status().get_height(),
+                            spend_horizon,
+                            note.refetch_nullifier_ranges(),
+                        ))
             },
             account_id,
         )?;

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -1,6 +1,5 @@
 //! All things needed to create, manaage, and use notes
 
-use pepper_sync::sync::ScanPriority;
 use pepper_sync::wallet::KeyIdInterface;
 use shardtree::store::ShardStore;
 use zcash_primitives::consensus::BlockHeight;
@@ -294,29 +293,12 @@ impl LightWallet {
                                 )
                                 && !exclude.contains(&note.output_id())
                                 && note.key_id().account_id() == account
-                                && if include_potentially_spent_notes {
-                                    true
-                                } else {
-                                    // checks all ranges above the note height are scanned and that the nullifiers were re-fetched
-                                    // if any of these ranges discarded the nullifiers *before* the note was scanned (due to memory constraints).
-                                    transaction.status().get_height() >= spend_horizon
-                                        && note.refetch_nullifier_ranges().iter().all(
-                                            |refetch_nullifier_range| {
-                                                self.sync_state.scan_ranges().iter().any(
-                                                    |scan_range| {
-                                                        scan_range.priority()
-                                                            == ScanPriority::Scanned
-                                                            && scan_range.block_range().contains(
-                                                                &refetch_nullifier_range.start,
-                                                            )
-                                                            && scan_range.block_range().contains(
-                                                                &(refetch_nullifier_range.end - 1),
-                                                            )
-                                                    },
-                                                )
-                                            },
-                                        )
-                                }
+                                && (include_potentially_spent_notes
+                                    || self.note_spends_confirmed(
+                                        transaction.status().get_height(),
+                                        spend_horizon,
+                                        note.refetch_nullifier_ranges(),
+                                    ))
                         })
                         .collect::<Vec<_>>()
                 } else {

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -207,6 +207,27 @@ impl LightWallet {
                 .map(|range| range.block_range().start)
         }
     }
+
+    /// Returns `true` if all nullifiers above `note_height` have been checked for this note's spend status.
+    ///
+    /// Requires that `note_height >= spend_horizon` (all ranges above the note are scanned) and that every
+    /// `refetch_nullifier_range` recorded on the note is fully contained within a `Scanned` scan range
+    /// (nullifiers that were discarded due to memory constraints have since been re-fetched).
+    pub(crate) fn note_spends_confirmed(
+        &self,
+        note_height: BlockHeight,
+        spend_horizon: BlockHeight,
+        refetch_nullifier_ranges: &[std::ops::Range<BlockHeight>],
+    ) -> bool {
+        note_height >= spend_horizon
+            && refetch_nullifier_ranges.iter().all(|refetch_range| {
+                self.sync_state.scan_ranges().iter().any(|scan_range| {
+                    scan_range.priority() == ScanPriority::Scanned
+                        && scan_range.block_range().contains(&refetch_range.start)
+                        && scan_range.block_range().contains(&(refetch_range.end - 1))
+                })
+            })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I am not certain that it's impossible for a ScannedWithoutMapping to be rescanned even though local state (the client) "knows" there are 0 unspent notes below it.

If unnecessary rescans can be avoided this will improve sync performance as a function of a few variables including network dependent (throughput, availability, etc.) ones.

This PR implements a check that short circuits rescan of ScannedWithoutMapping in the case that there are 0 unspent notes below the range that would be rescanned.

By recursing on the check the implementation ensures that all contiguous ScannedWithoutMapping ranges a correctly handled...   i.e. simple switched to scanpriority "Scanned".